### PR TITLE
Improve Part.Shape.project documentation

### DIFF
--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -495,7 +495,7 @@ Orientation is not taken into account.</UserDocu>
     </Methode>
     <Methode Name="project" Const="true">
       <Documentation>
-        <UserDocu>Project a shape on this shape</UserDocu>
+        <UserDocu>Project a list of shapes on this shape</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="makeParallelProjection" Const="true">


### PR DESCRIPTION
This clarifies that Part.Shape.project expects a list of shapes as an argument, not a single shape.  See [this forum thread](https://forum.freecadweb.org/viewtopic.php?f=22&t=23287) that highlights the confusion.